### PR TITLE
chore: pre-generate v6.0.0 freeze Safe batches for mainnets

### DIFF
--- a/contracts/safe-batches/10_freeze_v6_0_0.json
+++ b/contracts/safe-batches/10_freeze_v6_0_0.json
@@ -1,0 +1,50 @@
+{
+  "version": "1.0",
+  "chainId": "10",
+  "createdAt": 1777333776721,
+  "meta": {
+    "name": "Freeze SP1 v6.0.0 Routes",
+    "description": "Freeze v6.0.0 verifiers on Optimism",
+    "checksum": "0xbcc888e93ba6998433971c3b82c43c302453f994b4aff605de6be15e5a7fb914"
+  },
+  "transactions": [
+    {
+      "to": "0x397A5f7f3dBd538f23DE225B51f532c34448dA9B",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          }
+        ],
+        "name": "freezeRoute",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "selector": "0x0e78f4db"
+      }
+    },
+    {
+      "to": "0x3B6041173B80E77f038f3F2C0f9744f04837185e",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          }
+        ],
+        "name": "freezeRoute",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "selector": "0xbb1a6f29"
+      }
+    }
+  ]
+}

--- a/contracts/safe-batches/1_freeze_v6_0_0.json
+++ b/contracts/safe-batches/1_freeze_v6_0_0.json
@@ -1,0 +1,50 @@
+{
+  "version": "1.0",
+  "chainId": "1",
+  "createdAt": 1777333776645,
+  "meta": {
+    "name": "Freeze SP1 v6.0.0 Routes",
+    "description": "Freeze v6.0.0 verifiers on Ethereum",
+    "checksum": "0x364492feed342204c03746514ac2da8d0eea219f03f38acda714eead76ca1f94"
+  },
+  "transactions": [
+    {
+      "to": "0x397A5f7f3dBd538f23DE225B51f532c34448dA9B",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          }
+        ],
+        "name": "freezeRoute",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "selector": "0x0e78f4db"
+      }
+    },
+    {
+      "to": "0x3B6041173B80E77f038f3F2C0f9744f04837185e",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          }
+        ],
+        "name": "freezeRoute",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "selector": "0xbb1a6f29"
+      }
+    }
+  ]
+}

--- a/contracts/safe-batches/42161_freeze_v6_0_0.json
+++ b/contracts/safe-batches/42161_freeze_v6_0_0.json
@@ -1,0 +1,50 @@
+{
+  "version": "1.0",
+  "chainId": "42161",
+  "createdAt": 1777333776742,
+  "meta": {
+    "name": "Freeze SP1 v6.0.0 Routes",
+    "description": "Freeze v6.0.0 verifiers on Arbitrum",
+    "checksum": "0x5d092287a83a943a0de83f9fb6dd0d50f13afad5e501bd2e1839d7418728becd"
+  },
+  "transactions": [
+    {
+      "to": "0x397A5f7f3dBd538f23DE225B51f532c34448dA9B",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          }
+        ],
+        "name": "freezeRoute",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "selector": "0x0e78f4db"
+      }
+    },
+    {
+      "to": "0x3B6041173B80E77f038f3F2C0f9744f04837185e",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          }
+        ],
+        "name": "freezeRoute",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "selector": "0xbb1a6f29"
+      }
+    }
+  ]
+}

--- a/contracts/safe-batches/8453_freeze_v6_0_0.json
+++ b/contracts/safe-batches/8453_freeze_v6_0_0.json
@@ -1,0 +1,50 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1777333776756,
+  "meta": {
+    "name": "Freeze SP1 v6.0.0 Routes",
+    "description": "Freeze v6.0.0 verifiers on Base",
+    "checksum": "0x51a6a9f07ac825c66f9e09a1492b3435a68196d46cbf440e88f6897f425eefc1"
+  },
+  "transactions": [
+    {
+      "to": "0x397A5f7f3dBd538f23DE225B51f532c34448dA9B",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          }
+        ],
+        "name": "freezeRoute",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "selector": "0x0e78f4db"
+      }
+    },
+    {
+      "to": "0x3B6041173B80E77f038f3F2C0f9744f04837185e",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "internalType": "bytes4",
+            "name": "selector",
+            "type": "bytes4"
+          }
+        ],
+        "name": "freezeRoute",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "selector": "0xbb1a6f29"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Pre-generates the four mainnet Safe batch JSONs to freeze the v6.0.0 routes (Groth16 selector \`0x0e78f4db\`, Plonk selector \`0xbb1a6f29\`) on the Group A multisig gateways.

Generated via:
\`\`\`
node script/utils/generate-safe-batch.js --version=v6.0.0 --action=freeze
\`\`\`

Each batch holds 2 \`freezeRoute(bytes4)\` calls (Groth16 gateway + Plonk gateway). Files:
- \`safe-batches/1_freeze_v6_0_0.json\` — Ethereum
- \`safe-batches/10_freeze_v6_0_0.json\` — Optimism
- \`safe-batches/42161_freeze_v6_0_0.json\` — Arbitrum
- \`safe-batches/8453_freeze_v6_0_0.json\` — Base

Network is already on SP1 v6.1.0 (succinctlabs/sp1-contracts#75 rolled out), so v6.0.0 routes are dead and ready to freeze. Multisig signers can upload these directly to Safe Transaction Builder; no script run needed on their side.

Tracking issue: succinctlabs/apps-ops#3