### PR TITLE
chore: unpinned compiler version in 'v6.1.0/Groth16Verifier.sol'

### DIFF
--- a/contracts/src/v6.1.0/Groth16Verifier.sol
+++ b/contracts/src/v6.1.0/Groth16Verifier.sol
@@ -1,7 +1,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.20;
+pragma solidity ^0.8.20;
 
 /// @title Groth16 verifier template.
 /// @author Remco Bloemen


### PR DESCRIPTION
I noticed that the compiler version is not pinned in all the other verifier contracts, including in `v6.1.0`. So I assumed that this is not intentional.